### PR TITLE
Add custom prefix feature

### DIFF
--- a/ScreenshotTool.spec
+++ b/ScreenshotTool.spec
@@ -2,17 +2,17 @@
 
 
 a = Analysis(
-    ['G:\\u2dProject\\u6project\\VESPERIX\\scripts\\windows-screenshot-tool-forcc\\screenshot_gui.py'],
+    ['screenshot_gui.py'],
     pathex=[],
     binaries=[],
-    datas=[('screenshot_config.json', '.')],
-    hiddenimports=['PIL', 'PIL.Image', 'PIL.ImageTk', 'PIL.ImageGrab', 'PIL.ImageDraw', 'pyperclip', 'keyboard', 'pystray', 'pystray._base', 'pystray._win32', 'tkinter', 'tkinter.ttk', 'tkinter.filedialog', 'tkinter.messagebox', 'json', 'threading', 'pathlib', 'datetime', 'ctypes', 'ctypes.wintypes', 'win32gui', 'win32ui', 'win32con', 'subprocess', 'screenshot_tool_new', 'sys', 'os', 'traceback'],
+    datas=[],
+    hiddenimports=[],
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],
-    excludes=['matplotlib', 'numpy', 'pandas', 'scipy', 'cv2', 'torch', 'tensorflow'],
+    excludes=[],
     noarchive=False,
-    optimize=2,
+    optimize=0,
 )
 pyz = PYZ(a.pure)
 
@@ -21,11 +21,11 @@ exe = EXE(
     a.scripts,
     a.binaries,
     a.datas,
-    [('O', None, 'OPTION'), ('O', None, 'OPTION')],
+    [],
     name='ScreenshotTool',
     debug=False,
     bootloader_ignore_signals=False,
-    strip=True,
+    strip=False,
     upx=True,
     upx_exclude=[],
     runtime_tmpdir=None,

--- a/dist/screenshot_config.json
+++ b/dist/screenshot_config.json
@@ -1,15 +1,15 @@
 {
     "save_directory": "G:/u2dProject/u6project/VESPERIX/screenshots",
-    "file_prefix": "screenshot_",
+    "file_prefix": "shot_",
     "file_format": "png",
-    "hotkey": "ctrl+shift+s",
+    "hotkey": "ctrl+alt+s",
     "auto_copy_path": true,
+    "show_notifications": true,
+    "auto_open_folder": false,
     "show_preview": false,
-    "image_quality": 60,
-    "show_success_popup": false,
-    "optimize_image": true,
-    "png_compress_level": 6,
-    "screenshot_mode": "auto",
     "quality_preset": "low",
-    "language": "zh"
+    "show_success_popup": false,
+    "screenshot_mode": "auto",
+    "language": "en",
+    "custom_prefix": "read image: "
 }

--- a/screenshot_config.json
+++ b/screenshot_config.json
@@ -10,5 +10,6 @@
     "quality_preset": "low",
     "show_success_popup": false,
     "screenshot_mode": "auto",
-    "language": "en"
+    "language": "en",
+    "custom_prefix": "read image: "
 }

--- a/screenshot_gui.py
+++ b/screenshot_gui.py
@@ -87,6 +87,8 @@ class ScreenshotGUI:
                 "quality_warning": "⚠️ 警告：高质量模式会生成较大的文件，可能消耗大量token！\n建议仅在必要时使用高质量模式。",
                 "auto_copy_path": "自动复制路径到剪贴板",
                 "show_preview": "显示预览窗口",
+                "custom_prefix": "自定义前缀:",
+                "prefix_tip": "💡 前缀将添加到剪贴板内容的开头，例如：'![截图](' 或 '图片：'",
                 "hotkey": "热键:",
                 "hotkey_disabled": "热键未启用",
                 "hotkey_enabled": "热键已启用",
@@ -142,6 +144,8 @@ class ScreenshotGUI:
                 "quality_warning": "⚠️ Warning: High quality mode generates large files that may consume many tokens!\nUse high quality mode only when necessary.",
                 "auto_copy_path": "Auto copy path to clipboard",
                 "show_preview": "Show preview window",
+                "custom_prefix": "Custom Prefix:",
+                "prefix_tip": "💡 Prefix will be added to the beginning of clipboard content, e.g., '![Screenshot](' or 'Image: '",
                 "hotkey": "Hotkey:",
                 "hotkey_disabled": "Hotkey disabled",
                 "hotkey_enabled": "Hotkey enabled",
@@ -322,10 +326,31 @@ class ScreenshotGUI:
         self.ui_elements['copy_path_cb'] = self.copy_path_cb
         
         self.show_preview_var = tk.BooleanVar()
-        self.show_preview_cb = tk.Checkbutton(options_frame, text=self.tr("show_preview"), 
+        self.show_preview_cb = tk.Checkbutton(options_frame, text=self.tr("show_preview"),
                       variable=self.show_preview_var)
         self.show_preview_cb.pack(anchor=tk.W)
         self.ui_elements['show_preview_cb'] = self.show_preview_cb
+
+        # 自定义前缀设置
+        prefix_frame = tk.Frame(self.settings_frame)
+        prefix_frame.pack(fill=tk.X, padx=10, pady=5)
+
+        self.prefix_label = tk.Label(prefix_frame, text=self.tr("custom_prefix"))
+        self.prefix_label.pack(side=tk.LEFT)
+        self.ui_elements['prefix_label'] = self.prefix_label
+
+        self.prefix_var = tk.StringVar()
+        self.prefix_entry = tk.Entry(prefix_frame, textvariable=self.prefix_var, width=30)
+        self.prefix_entry.pack(side=tk.LEFT, padx=5)
+
+        # 前缀提示
+        prefix_tip_frame = tk.Frame(self.settings_frame)
+        prefix_tip_frame.pack(fill=tk.X, padx=10, pady=2)
+
+        self.prefix_tip_label = tk.Label(prefix_tip_frame, text=self.tr("prefix_tip"),
+                font=("Arial", 9), fg="#6c757d")
+        self.prefix_tip_label.pack(anchor=tk.W)
+        self.ui_elements['prefix_tip_label'] = self.prefix_tip_label
         
         # 热键设置
         self.hotkey_frame = tk.LabelFrame(main_frame, text=self.tr("hotkey_settings"), pady=10)
@@ -503,6 +528,10 @@ class ScreenshotGUI:
                 element.config(text=self.tr("auto_copy_path"))
             elif key == 'show_preview_cb':
                 element.config(text=self.tr("show_preview"))
+            elif key == 'prefix_label':
+                element.config(text=self.tr("custom_prefix"))
+            elif key == 'prefix_tip_label':
+                element.config(text=self.tr("prefix_tip"))
             elif key == 'hotkey_frame':
                 element.config(text=self.tr("hotkey_settings"))
             elif key == 'hotkey_label':
@@ -565,8 +594,9 @@ class ScreenshotGUI:
         self.quality_var.set(self.config.get("quality_preset", "low"))
         self.copy_path_var.set(self.config.get("auto_copy_path", True))
         self.show_preview_var.set(self.config.get("show_preview", True))
+        self.prefix_var.set(self.config.get("custom_prefix", "read image: "))
         self.hotkey_var.set(self.config.get("hotkey", "ctrl+shift+s"))
-        
+
         # 触发质量改变事件
         self.on_quality_change()
     
@@ -576,9 +606,10 @@ class ScreenshotGUI:
         self.config.set("quality_preset", self.quality_var.get())
         self.config.set("auto_copy_path", self.copy_path_var.get())
         self.config.set("show_preview", self.show_preview_var.get())
+        self.config.set("custom_prefix", self.prefix_var.get())
         self.config.set("hotkey", self.hotkey_var.get())
         self.config.set("language", self.current_language)
-        
+
         if self.config.save_config():
             messagebox.showinfo(self.tr("settings_saved"), self.tr("settings_saved_msg"))
         else:

--- a/screenshot_tool_new.py
+++ b/screenshot_tool_new.py
@@ -79,7 +79,8 @@ class ScreenshotConfig:
             "show_preview": True,
             "quality_preset": "low",  # low, medium, high
             "show_success_popup": False,
-            "screenshot_mode": "auto"
+            "screenshot_mode": "auto",
+            "custom_prefix": "read image: "  # 自定义前缀，默认为"read image: "
         }
         self.config = self.load_config()
     
@@ -895,9 +896,9 @@ class ScreenshotTool:
             
             # 保存图片（优化压缩）
             if self.save_optimized_image(img, str(filepath)):
-                # 复制路径到剪贴板
+                # 复制路径到剪贴板（支持自定义前缀）
                 if self.config.get("auto_copy_path", True):
-                    pyperclip.copy(str(filepath))
+                    self.copy_to_clipboard_with_prefix(str(filepath))
                 
                 # 显示成功消息（可选）
                 if self.config.get("show_success_popup", False):
@@ -912,7 +913,35 @@ class ScreenshotTool:
         except Exception as e:
             print(f"保存失败: {e}")
             messagebox.showerror("错误", f"保存失败: {e}")
-    
+
+    def copy_to_clipboard_with_prefix(self, filepath):
+        """复制路径到剪贴板，支持自定义前缀"""
+        try:
+            # 获取自定义前缀
+            custom_prefix = self.config.get("custom_prefix", "")
+
+            # 构建最终的剪贴板内容
+            if custom_prefix:
+                # 如果有自定义前缀，添加到路径前面
+                clipboard_content = custom_prefix + str(filepath)
+            else:
+                # 没有前缀，直接使用路径
+                clipboard_content = str(filepath)
+
+            # 复制到剪贴板
+            pyperclip.copy(clipboard_content)
+
+            print(f"已复制到剪贴板: {clipboard_content}")
+
+        except Exception as e:
+            print(f"复制到剪贴板失败: {e}")
+            # 如果复制失败，尝试只复制路径
+            try:
+                pyperclip.copy(str(filepath))
+                print(f"已复制路径到剪贴板: {filepath}")
+            except:
+                print("剪贴板操作完全失败")
+
     def save_optimized_image(self, img, filepath):
         """保存优化后的图片"""
         try:


### PR DESCRIPTION
✨ 新增自定义前缀功能:
- 添加自定义前缀输入框到GUI界面
- 支持中英文界面切换
- 默认前缀设置为 'read image: '
- 剪贴板内容将自动添加前缀
- 更新配置文件和核心截图功能
- 重新编译可执行文件

🎯 使用场景:
- 方便Claude Code读取图片时的标识
- 支持Markdown格式前缀如 '![截图]('
- 可自定义任意前缀文本